### PR TITLE
Keyword replacement for Codespaces port forwarding domain

### DIFF
--- a/.auth0/lab/resources.yml
+++ b/.auth0/lab/resources.yml
@@ -6,7 +6,7 @@ clients: # Add other client settings https://auth0.com/docs/api/management/v2#!/
      alg: "RS256"
     callbacks:
       - "http://localhost:37500/callback"
-      - https://##CODESPACE_NAME##-37500.app.github.dev/callback
+      - https://##CODESPACE_NAME##-37500.##GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN##/callback
     allowed_logout_urls:
       - "http://localhost:37500"
-      - https://##CODESPACE_NAME##-37500.app.github.dev
+      - https://##CODESPACE_NAME##-37500.##GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN##


### PR DESCRIPTION
1. Launch lab in Codespaces
2. Ensure the extension config pulls down the correct URIs for Allowed login and callback URLs